### PR TITLE
Fix OOM error

### DIFF
--- a/serverless.sh
+++ b/serverless.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export NODE_OPTIONS=--max_old_space_size=8192
+
 cd disclosure-deploy-repository
 echo Installing dependancies
 serverless plugin install --name serverless-latest-layer-version


### PR DESCRIPTION
This may fix the OOM error seen on the CI/CD env:

"FATAL ERROR: Ineffective mark-compacts near heap 
limit Allocation failed - JavaScript heap out of memory"