### PR TITLE
Marshmallow Updated.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -52,7 +52,7 @@ jsonpickle==1.2
 jsonpointer==2.0
 jsonschema==2.6.0
 markupsafe==1.1.1
-marshmallow==2.19.5
+marshmallow==3.6.0
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==7.0.0 ; python_version > '2.7'

--- a/stage2_method.py
+++ b/stage2_method.py
@@ -1,24 +1,28 @@
 import json
 import logging
 
-import marshmallow
 import pandas as pd
 from es_aws_functions import general_functions
+from marshmallow import EXCLUDE, Schema, fields
 
 
-class RuntimeSchema(marshmallow.Schema):
-    """
-    Class to set up the environment variables schema.
-    """
-    disclosivity_marker = marshmallow.fields.Str(required=True)
-    publishable_indicator = marshmallow.fields.Str(required=True)
-    explanation = marshmallow.fields.Str(required=True)
-    parent_column = marshmallow.fields.Str(required=True)
-    threshold = marshmallow.fields.Str(required=True)
-    data = marshmallow.fields.Str(required=True)
-    unique_identifier = marshmallow.fields.List(marshmallow.fields.Str(), required=True)
-    total_columns = marshmallow.fields.List(marshmallow.fields.Str(), required=True)
-    run_id = marshmallow.fields.Str(required=True)
+class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
+    disclosivity_marker = fields.Str(required=True)
+    publishable_indicator = fields.Str(required=True)
+    explanation = fields.Str(required=True)
+    parent_column = fields.Str(required=True)
+    threshold = fields.Str(required=True)
+    data = fields.Str(required=True)
+    unique_identifier = fields.List(fields.Str(), required=True)
+    total_columns = fields.List(fields.Str(), required=True)
+    run_id = fields.Str(required=True)
 
 
 def lambda_handler(event, context):
@@ -50,10 +54,7 @@ def lambda_handler(event, context):
         # Because it is used in exception handling
         run_id = event["RuntimeVariables"]["run_id"]
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/stage5_method.py
+++ b/stage5_method.py
@@ -1,26 +1,30 @@
 import json
 import logging
 
-import marshmallow
 import pandas as pd
 from es_aws_functions import general_functions
+from marshmallow import EXCLUDE, Schema, fields
 
 
-class RuntimeSchema(marshmallow.Schema):
-    """
-    Class to set up the environment variables schema.
-    """
-    disclosivity_marker = marshmallow.fields.Str(required=True)
-    publishable_indicator = marshmallow.fields.Str(required=True)
-    explanation = marshmallow.fields.Str(required=True)
-    top1_column = marshmallow.fields.Str(required=True)
-    top2_column = marshmallow.fields.Str(required=True)
-    cell_total_column = marshmallow.fields.Str(required=True)
-    data = marshmallow.fields.Str(required=True)
-    threshold = marshmallow.fields.Str(required=True)
-    unique_identifier = marshmallow.fields.List(marshmallow.fields.Str(), required=True)
-    total_columns = marshmallow.fields.List(marshmallow.fields.Str(), required=True)
-    run_id = marshmallow.fields.Str(required=True)
+class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
+    disclosivity_marker = fields.Str(required=True)
+    publishable_indicator = fields.Str(required=True)
+    explanation = fields.Str(required=True)
+    top1_column = fields.Str(required=True)
+    top2_column = fields.Str(required=True)
+    cell_total_column = fields.Str(required=True)
+    data = fields.Str(required=True)
+    threshold = fields.Str(required=True)
+    unique_identifier = fields.List(fields.Str(), required=True)
+    total_columns = fields.List(fields.Str(), required=True)
+    run_id = fields.Str(required=True)
 
 
 def lambda_handler(event, context):
@@ -54,10 +58,7 @@ def lambda_handler(event, context):
         # Because it is used in exception handling
         run_id = event["RuntimeVariables"]["run_id"]
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 


### PR DESCRIPTION
Moving Marshmallow on from 2.19.5 to 3.6.0 because support for 2.19.5 ends on 18/08/2020.

Updates are fairly straightforward:
Add meta class so that excess variables are excluded.

Override the basic Marshmallow Error with out custom one. This moved it out of the main code block and into the Schema itself.