### PR TITLE
added bpm status message to disclosure

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -107,3 +107,4 @@ xmltodict==0.12.0
 yamllint==1.20.0
 zipp==0.5.1
 git+https://github.com/ONSdigital/es-functions.git
+#forcing new build

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -107,4 +107,3 @@ xmltodict==0.12.0
 yamllint==1.20.0
 zipp==0.5.1
 git+https://github.com/ONSdigital/es-functions.git
-#forcing new build

--- a/stage1_method.py
+++ b/stage1_method.py
@@ -14,6 +14,7 @@ class RuntimeSchema(Schema):
         logging.error(f"Error validating runtime params: {e}")
         raise ValueError(f"Error validating runtime params: {e}")
 
+    bpm_queue_url = fields.Str(required=True)
     disclosivity_marker = fields.Str(required=True)
     publishable_indicator = fields.Str(required=True)
     explanation = fields.Str(required=True)
@@ -29,6 +30,7 @@ def lambda_handler(event, context):
     Main entry point into method
     :param event: json payload containing:
             data: input data.
+            bpm_queue_url: Queue url to send BPM status message.
             disclosivity_marker: The name of the column to put "disclosive" marker.
             publishable_indicator: The name of the column to put "publish" marker.
             explanation: The name of the column to put reason for pass/fail.
@@ -42,6 +44,8 @@ def lambda_handler(event, context):
     current_module = "Disclosure Stage 1 Method"
     error_message = ""
     logger = general_functions.get_logger()
+    # Set-up variables for status message
+    bpm_queue_url = None
     # Define run_id outside of try block
     run_id = 0
     try:
@@ -54,6 +58,7 @@ def lambda_handler(event, context):
         logger.info("Validated parameters.")
 
         # Runtime Variables
+        bpm_queue_url = runtime_variables["bpm_queue_url"]
         disclosivity_marker = runtime_variables["disclosivity_marker"]
         publishable_indicator = runtime_variables["publishable_indicator"]
         explanation = runtime_variables["explanation"]
@@ -97,7 +102,8 @@ def lambda_handler(event, context):
 
     except Exception as e:
         error_message = general_functions.handle_exception(e, current_module,
-                                                           run_id, context)
+                                                           run_id, context=context,
+                                                           bpm_queue_url=bpm_queue_url)
     finally:
         if (len(error_message)) > 0:
             logger.error(error_message)

--- a/stage2_method.py
+++ b/stage2_method.py
@@ -14,6 +14,7 @@ class RuntimeSchema(Schema):
         logging.error(f"Error validating runtime params: {e}")
         raise ValueError(f"Error validating runtime params: {e}")
 
+    bpm_queue_url = fields.Str(required=True)
     disclosivity_marker = fields.Str(required=True)
     publishable_indicator = fields.Str(required=True)
     explanation = fields.Str(required=True)
@@ -30,6 +31,7 @@ def lambda_handler(event, context):
     Main entry point into method
     :param event: json payload containing:
             data: input data.
+            bpm_queue_url: Queue url to send BPM status message.
             disclosivity_marker: The name of the column to put "disclosive" marker.
             publishable_indicator: The name of the column to put "publish" marker.
             explanation: The name of the column to put reason for pass/fail.
@@ -46,6 +48,8 @@ def lambda_handler(event, context):
     current_module = "Disclosure Stage 2 Method"
     error_message = ""
     logger = general_functions.get_logger()
+    # Set-up variables for status message
+    bpm_queue_url = None
     # Define run_id outside of try block
     run_id = 0
     try:
@@ -58,6 +62,7 @@ def lambda_handler(event, context):
         logger.info("Validated parameters.")
 
         # Runtime Variables
+        bpm_queue_url = runtime_variables["bpm_queue_url"]
         disclosivity_marker = runtime_variables["disclosivity_marker"]
         publishable_indicator = runtime_variables["publishable_indicator"]
         explanation = runtime_variables["explanation"]
@@ -103,7 +108,8 @@ def lambda_handler(event, context):
 
     except Exception as e:
         error_message = general_functions.handle_exception(e, current_module,
-                                                           run_id, context)
+                                                           run_id, context=context,
+                                                           bpm_queue_url=bpm_queue_url)
     finally:
         if (len(error_message)) > 0:
             logger.error(error_message)

--- a/tests/fixtures/test_wrangler_to_method_runtime.json
+++ b/tests/fixtures/test_wrangler_to_method_runtime.json
@@ -1,4 +1,5 @@
 {
+    "bpm_queue_url": "fake_queue_url",
     "cell_total_column": "cell_total",
     "data": null,
     "disclosivity_marker": "disclosive",

--- a/tests/test_disclosure.py
+++ b/tests/test_disclosure.py
@@ -19,6 +19,7 @@ wrangler_environment_variables = {
 
 method_runtime_variables_1 = {
     "RuntimeVariables": {
+        "bpm_queue_url": "fake_queue_url",
         "cell_total_column": "cell_total",
         "disclosivity_marker": "disclosive",
         "explanation": "reason",
@@ -32,6 +33,7 @@ method_runtime_variables_1 = {
 
 method_runtime_variables_2 = {
     "RuntimeVariables": {
+        "bpm_queue_url": "fake_queue_url",
         "disclosivity_marker": "disclosive",
         "explanation": "reason",
         "data": None,
@@ -46,6 +48,7 @@ method_runtime_variables_2 = {
 
 method_runtime_variables_5 = {
     "RuntimeVariables": {
+        "bpm_queue_url": "fake_queue_url",
         "cell_total_column": "cell_total",
         "disclosivity_marker": "disclosive",
         "explanation": "reason",
@@ -63,6 +66,7 @@ method_runtime_variables_5 = {
 wrangler_runtime_variables = {
     "RuntimeVariables":
         {
+            "bpm_queue_url": "fake_queue_url",
             "cell_total_column": "cell_total",
             "disclosivity_marker": "disclosive",
             "disclosure_stages": "1 2 5",
@@ -79,6 +83,7 @@ wrangler_runtime_variables = {
             "top1_column": "largest_contributor",
             "top2_column": "second_largest_contributor",
             "total_columns": ["Q608_total", "Q606_other_gravel"],
+            "total_steps": "6",
             "unique_identifier": ["responder_id"]
         }
 }
@@ -96,7 +101,8 @@ wrangler_runtime_variables = {
          wrangler_environment_variables, None,
          "ClientError", test_generic_library.wrangler_assert)
     ])
-def test_client_error(which_lambda, which_runtime_variables,
+@mock.patch('disclosure_wrangler.aws_functions.send_bpm_status')
+def test_client_error(mock_send_bpm_status, which_lambda, which_runtime_variables,
                       which_environment_variables, which_data,
                       expected_message, assertion):
     test_generic_library.client_error(which_lambda, which_runtime_variables,
@@ -154,8 +160,9 @@ def test_incomplete_read_error():
         (lambda_wrangler_function, wrangler_environment_variables,
          "KeyError", test_generic_library.wrangler_assert, None)
     ])
-def test_key_error(which_lambda, which_environment_variables, expected_message,
-                   assertion, which_runtime_variables):
+@mock.patch('disclosure_wrangler.aws_functions.send_bpm_status')
+def test_key_error(mock_send_bpm_status, which_lambda, which_environment_variables,
+                   expected_message, assertion, which_runtime_variables):
     if which_runtime_variables is None:
         test_generic_library.key_error(which_lambda,
                                        which_environment_variables,


### PR DESCRIPTION
Sets the status message for the stage "IN PROGRESS" for beginning "DONE" for end and "ERROR" for error/failure.
Calls "send_bpm_status" function from the functions library passing the queue url from config with status message and the run_id and module name.