### PR TITLE
Missed payload for subsequent disclosure methods added.

### DIFF
--- a/disclosure_wrangler.py
+++ b/disclosure_wrangler.py
@@ -218,11 +218,13 @@ def lambda_handler(event, context):
                 "bpm_queue_url": bpm_queue_url,
                 "data": formatted_data["data"],
                 "disclosivity_marker": disclosivity_marker,
-                "publishable_indicator": publishable_indicator,
+                "environment": environment,
                 "explanation": explanation,
+                "publishable_indicator": publishable_indicator,
+                "run_id": run_id,
+                "survey": survey,
                 "total_columns": total_columns,
-                "unique_identifier": unique_identifier,
-                "run_id": run_id
+                "unique_identifier": unique_identifier
             }
 
         aws_functions.save_to_s3(bucket_name, out_file_name, formatted_data["data"])


### PR DESCRIPTION
The loop that calls the disclosure methods has a reset to the payload at the end of each iteration that was missing survey and environment so subsequent disclosure methods were missing these params. This fixes that issue.